### PR TITLE
Make TargetHeatingCoolingState writable

### DIFF
--- a/platforms/ZWayServer.js
+++ b/platforms/ZWayServer.js
@@ -458,7 +458,12 @@ ZWayServerAccessory.prototype = {
                 debug("Getting value for " + vdev.metrics.title + ", characteristic \"" + cx.displayName + "\"...");
                 callback(false, Characteristic.TargetHeatingCoolingState.HEAT);
             });
-            cx.writable = false;
+            // Hmm... apparently if this is not setable, we can't add a thermostat change to a scene. So, make it writable but a no-op.
+            cx.writable = true;
+            cx.on('set', function(newValue, callback){
+                debug("WARN: Set of TargetHeatingCoolingState not yet implemented, resetting to HEAT!")
+                callback(undefined, Characteristic.TargetHeatingCoolingState.HEAT);
+            }.bind(this));
             return cx;
         }
         


### PR DESCRIPTION
Apparently, if TargetHeatingCoolingState is not writable, you can’t add
a thermostat to a scene. This fix makes it writable from HomeKit, but
it still always remains set to HEAT.
